### PR TITLE
Fix typo

### DIFF
--- a/layouts/partials/home/copy.html
+++ b/layouts/partials/home/copy.html
@@ -96,9 +96,9 @@
           <div class="fmw-575 w-100">
             <p>
               Our Saturday-morning egg drop schedule will continue through the
-              the month of April. You will find us at the Scituate Rotary
-              Farmers Market site (46 Institute Lane in North Scituate) on
-              Saturdays from 10 to 11 AM.
+              month of April. You will find us at the Scituate Rotary Farmers
+              Market site (46 Institute Lane in North Scituate) on Saturdays
+              from 10 to 11 AM.
             </p>
             <p>
               Changes to our schedule and periodic updates will be posted on


### PR DESCRIPTION
Remove redundant "the" from home page update copy.