### PR TITLE
Consolidate redirects and drop the wildcard CORS header

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -32,6 +32,12 @@ command = "yarn deploy && hugo --gc --buildDrafts --buildExpired --buildFuture -
   status = 301
   force = false
 
+[[redirects]]
+  from = "/privacy-policy"
+  to = "/privacy"
+  status = 301
+  force = false
+
 [[headers]]
   for = "/*"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -42,7 +42,6 @@ command = "yarn deploy && hugo --gc --buildDrafts --buildExpired --buildFuture -
   for = "/*"
 
   [headers.values]
-    Access-Control-Allow-Origin = "*"
     # HTML must never be cached for longer than a deploy takes to
     # matter. Netlify sends strong ETags, so this revalidates with a
     # cheap 304 rather than re-downloading the page.

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,0 @@
-/privacy-policy  /privacy


### PR DESCRIPTION
Two of the small, non-migration-blocking items left open in
`project-audit.md`'s A2 list.

**Move the privacy-policy redirect into netlify.toml.** Redirects lived
in two places: `netlify.toml` (`/admin`, `/dashboard`, `/venmo`) and
`static/_redirects` (`/privacy-policy` → `/privacy`). The latter is now
a `[[redirects]]` block like the others and the file is gone. `status`
is set to 301 explicitly, which is what `_redirects` defaulted to, so
the behaviour is unchanged.

**Drop the wildcard CORS header.** `Access-Control-Allow-Origin = "*"`
applied to `/*` with nothing on the site making a cross-origin request —
no `fetch`/`XMLHttpRequest` anywhere in `assets/scripts`, no
`crossorigin` attribute in any template, and the CSP already pins
`connect-src`/`font-src` to `'self'`.

## Verification

Built with the pinned toolchain (Hugo 0.164.0 extended + Dart Sass
1.79.5): build green, `npm run lint` clean, `netlify.toml` parses and
lists all four redirects. Static-file count drops 36 → 35, which is the
removed `_redirects`.

Redirect behaviour itself can only be confirmed on the deploy preview —
worth clicking `/privacy-policy` there before merging.

Not touched here: the HSTS `max-age` bump, which needs
`admin.northfosterfarm.com` confirmed HTTPS-only first (`includeSubDomains`
is set). Queued as a question in the relay ledger.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYfqseXoYjRg1SuAtzpw95)_