### PR TITLE
Rewrite the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,98 @@
 # ![North Foster Farm](./assets/images/logo-small.png) North Foster Farm
 
-Website for North Foster Farm, built with Hugo, and hosted with Netlify.
+The website for North Foster Farm — [northfosterfarm.com][site]. A
+static site built with [Hugo][hugo], styled with Bootstrap 5 and SCSS,
+and hosted on [Netlify][netlify].
+
+> [!WARNING]
+> **Pushing to `main` deploys the live public site.** There is no
+> staging step and no manual approval. Work on a branch, let the
+> Netlify deploy preview build, and merge once it is green.
+
+## Prerequisites
+
+- **Hugo 0.164.0, extended.** The extended build is the one that can
+  compile SCSS; the standard build cannot. Pinned in `netlify.toml`,
+  floored in `config/_default/hugo.toml`.
+- **Node 26.** Pinned in `.nvmrc` and as `NODE_VERSION` in
+  `netlify.toml`.
+- **npm.** `package-lock.json` is the lockfile. Netlify picks its
+  package manager from whichever lockfile it finds, so do not add a
+  `yarn.lock`.
+
+Keep Hugo where the pin is. On Homebrew that means `brew pin hugo`
+after installing, so a routine `brew upgrade` cannot quietly move local
+builds off the version Netlify uses — that gap is what the audit
+existed to close.
+
+## Getting started
+
+```bash
+npm install
+npm start
+```
+
+`npm start` runs `bin/dev`, which serves the site at
+<http://localhost:1313> with live reload and builds draft, future, and
+expired content so unpublished pages are visible.
+
+To reach the dev server from another device on the network — a phone,
+mostly — use `npm run start:bind`. It binds to this machine's LAN IP
+and expects `northfosterfarm.local` and `www.northfosterfarm.local` in
+`/etc/hosts`; it prints the exact lines to add if they are missing.
+
+## Checks
+
+```bash
+npm run lint            # both linters
+npm run lint:scripts    # ESLint, assets/scripts
+npm run lint:styles     # Stylelint, assets/styles
+```
+
+Lint gates the deploy — Netlify runs it as part of the build, so a lint
+error fails the deploy rather than shipping.
+
+To check a production build locally:
+
+```bash
+npm run lint && hugo --environment production
+```
+
+Note what is missing there. **Do not run `npm run deploy` locally** —
+it calls `bin/prod`, which installs Dart Sass into `/opt/build/repo`, a
+path that exists only on the Netlify build image, so locally it dies at
+`mkdir`. Install Dart Sass yourself (`brew install sass/sass/sass`) and
+Hugo will find it on `PATH`. If it is absent, Hugo 0.164 stops with
+`TOCSS-DART: failed to transform "/styles/main.scss"` instead of
+silently falling back to LibSass the way older versions did.
+
+## Layout
+
+```
+assets/          SCSS and JS, processed by Hugo Pipes
+config/          Hugo config, layered: _default, development, production
+content/         Markdown pages
+data/            company.yaml, socialMedia.yaml — read via hugo.Data
+layouts/         Templates; partials/ is heavily reused
+static/          Copied to the output verbatim
+bin/dev          Dev server wrapper
+bin/prod         Netlify-only build step (installs Dart Sass)
+```
+
+`CLAUDE.md` goes deeper on the architecture — the asset pipeline,
+SCSS import order, and where the site's data lives.
+
+## Deployment
+
+Netlify builds `npm run deploy && hugo --gc` and publishes `public/`.
+Every pull request gets a deploy preview built the same way production
+is, which is the safety net: a bad build fails the preview instead of
+the site.
+
+`netlify.toml` holds the build config, redirects, and security headers
+(CSP, HSTS, cache policy). It is the source of truth for all three, so
+redirects belong there rather than in a `static/_redirects` file.
+
+[site]: https://northfosterfarm.com
+[hugo]: https://gohugo.io
+[netlify]: https://www.netlify.com


### PR DESCRIPTION
The last open A3 item that needed no answer from you. The README was
three lines: a logo, and "built with Hugo, and hosted with Netlify". No
versions, no prerequisites, no commands, and — the part that actually
matters — no warning that pushing to `main` publishes the live site.

It now covers:

- **The auto-deploy warning, first thing after the intro**, as a
  callout. Someone arriving at this repo should not have to infer that
  `main` is production.
- **Prerequisites with the real pins**: Hugo 0.164.0 *extended* (and
  why extended — the standard build cannot compile SCSS), Node 26, npm.
  Each says where the pin lives, so the README does not become a fourth
  place a version can drift.
- **`brew pin hugo`**, because an unpinned `brew upgrade` re-opens
  exactly the local-vs-Netlify gap the audit closed.
- **The one-command dev loop**, plus what `start:bind` is for.
- **Lint gates the deploy** — worth knowing before a lint error fails a
  deploy.
- **A local production check that does not call `bin/prod`**, with the
  reason spelled out: `bin/prod` installs Dart Sass into
  `/opt/build/repo` and only works on the Netlify image. This has bitten
  before; the audit had to revert a rewrite of that script.
- **The Dart Sass requirement**, including the exact error Hugo 0.164
  now raises when it is missing.
- Directory layout and a pointer to `CLAUDE.md` for the deeper
  architecture, so the two files do not duplicate each other.

## Ordering

Written against npm, so **merge this after #76** (the yarn → npm
switch). No file conflict — #76 does not touch `README.md` — but
merging this first would leave the README describing a package manager
the repo has not adopted yet.

## Verification

Prose only; nothing here is a build input. Every command and version in
it was checked against the repo as it stands: the scripts in
`package.json`, the pins in `netlify.toml` / `.nvmrc` /
`config/_default/hugo.toml`, and `bin/dev`'s actual `/etc/hosts`
behaviour. The Dart Sass error text is quoted from a real failed build
in this container, not from memory.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYfqseXoYjRg1SuAtzpw95)_