### PR TITLE
Finish the CSP and drop the @popperjs/core declaration

### DIFF
--- a/docs/tailwind-inventory.md
+++ b/docs/tailwind-inventory.md
@@ -105,15 +105,31 @@ needs it:
   become plain `'self'` — and note the property is `--bs-*`, so the
   Tailwind migration deletes the need for it regardless.
 - **`script-src`** — six `<script type="application/ld+json">` schema
-  blocks. The one real `<script>` is external, with `src` + `integrity`,
-  so `'self'` already covers it. CSP does apply `script-src` to JSON-LD,
-  so those six are the only thing keeping `'unsafe-inline'` alive.
-  Options are a hash-based policy or emitting the schema as a file.
+  blocks, plus one external `<script>` with `src` + `integrity` that
+  `'self'` already covers. This section originally claimed CSP applies
+  `script-src` to JSON-LD, so those six blocks were holding
+  `'unsafe-inline'` in place, and proposed either a hash-based policy or
+  moving the schema to a file. **That was wrong.** `application/ld+json`
+  is a *data block*, not a script: the browser never executes it and CSP
+  never evaluates it.
 
-So `style-src` is a cheap win available today, and `script-src` is a
-slightly larger one; neither has to wait for Tailwind. This supersedes
-the "parked until after Tailwind" note in `project-audit.md` to the
-extent that the *measurement* is now done.
+  Measured in headless Chromium rather than argued: a page carrying
+  `script-src 'self'` with an inline JSON-LD block and an inline
+  executable `<script>` reports exactly one violation — the executable
+  one. The JSON-LD reports none. Repeated against the real built site
+  under the exact production policy, all four pages report zero
+  violations, with a `script-src 'none'` negative control confirming the
+  harness detects violations when they exist.
+
+  So `'unsafe-inline'` was doing nothing for `script-src` and has simply
+  been deleted. No hashes, no external file — which is just as well,
+  since Google's structured-data crawler requires JSON-LD inline and
+  moving it to a file would have traded a real SEO signal for no
+  security gain.
+
+Both `script-src` and `style-src` are now plain `'self'`. This
+supersedes the "parked until after Tailwind" note in
+`project-audit.md` — the CSP work is done, not deferred.
 
 ## Finding 4 — what is genuinely custom vs. an override
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -59,7 +59,7 @@ command = "npm run deploy && hugo --gc --buildDrafts --buildExpired --buildFutur
       frame-ancestors 'none';
       img-src 'self' data:;
       manifest-src 'self';
-      script-src 'self' 'unsafe-inline';
+      script-src 'self';
       style-src 'self';
     '''
     Referrer-Policy = "same-origin"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "north-foster-farm",
       "version": "1.0",
       "dependencies": {
-        "@popperjs/core": "2.11.8",
         "bootstrap": "5.3.3"
       },
       "devDependencies": {
@@ -429,6 +428,7 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "stylelint-scss": "6.8.1"
   },
   "dependencies": {
-    "@popperjs/core": "2.11.8",
     "bootstrap": "5.3.3"
   }
 }


### PR DESCRIPTION
Answers **Q10** and **Q11**, as two separate commits per your Q10 note.

## ⚠️ Q11: I recommended the wrong thing, and you approved it

You said "external fingerprinted file, not SHA-256 hashes". I built
neither, because **the premise of my own question was false**.

`application/ld+json` is a **data block**, not a script. The browser never
executes it, so CSP never evaluates it. Those six schema blocks were not
holding `'unsafe-inline'` in place — **nothing was**. The fix is to delete
it, full stop.

This also matters because the route I recommended would have been
*actively harmful*: `<script type="application/ld+json" src="...">` isn't
fetched by browsers, and Google's structured-data crawler wants JSON-LD
inline. Moving the schema to a file would have cost a real SEO signal on a
business site to buy exactly zero security.

### Measured, not argued

I tested it in the bundled headless Chromium rather than reasoning from
memory:

1. **Probe page** under `script-src 'self'`, carrying both an inline
   JSON-LD block and an inline executable `<script>`: exactly **1**
   violation reported, and it's the executable one
   (`script-src-elem | inline`). The JSON-LD reports nothing. The control
   script demonstrably did not run.
2. **The real built site** under the exact production policy: **0
   violations** on `/`, `/privacy/`, `/accessibility/` and `/404.html`.
3. **Negative control** — same site served with `script-src 'none'`:
   **1** violation. So the harness does detect violations when they exist,
   which is what makes the zeros above mean something.

Script inventory across the built site is 4 external module scripts (all
with `src` + `integrity`) and 6 JSON-LD data blocks. No inline executable
scripts at all.

**Both `script-src` and `style-src` are now plain `'self'`.** The CSP work
is finished rather than deferred, and `docs/tailwind-inventory.md` is
corrected — it asserted the opposite and proposed the file route.

## Q10 — `@popperjs/core`

Removed from `dependencies`. Nothing imports it; it was only ever
reachable through `bootstrap.esm.min.js`, and that import went in #81.

**One honest caveat:** this does *not* shrink `node_modules`. Bootstrap
5.3.3 declares `@popperjs/core` as a `peerDependency`, so npm still
installs it — the lockfile just re-tags the entry `"peer": true`. It's a
declaration fix (we no longer claim to depend on something we don't use),
and it disappears for real when Bootstrap does. I'd rather say that than
let it read as a size win.

## Verification

- Lint green; production build green (Hugo 0.164.0-extended + Dart Sass
  1.79.5).
- **Build output byte-identical** to pre-change across all of `public/`.
- CSP verified end-to-end as above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpJ4ZA7mB6y6TYvRHtfLQe)_