### PR TITLE
Bump js-yaml and fast-uri to clear two high-severity advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1306,9 +1306,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -1808,9 +1808,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
GitHub flagged a high-severity vulnerability on `main` during a routine push. `npm audit` reports two, both in **dev-only transitive dependencies**:

| package | change | advisory |
| --- | --- | --- |
| `js-yaml` | 4.3.0 → 4.3.1 | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption in `!!omap` resolution |
| `fast-uri` | 3.1.4 → 3.1.5 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — host confusion via backslash authority introducer |

## Why this is low urgency

Neither package reaches a visitor. `bootstrap` is the only runtime dependency and it audits clean — these two come in through the lint toolchain (`fast-uri` via eslint's ajv), and the only input they see during a build is the repo's own files. There is no untrusted input on that path, so this is alert hygiene rather than an incident. I did it now because the fix is two patch bumps and it stops the alert sitting on the default branch.

## Scope

Both fixes are in-range, so `package.json` is untouched and this is a **lockfile-only** change — 6 insertions, 6 deletions.

## Verification

- `npm install` → clean, `npm audit` → **0 vulnerabilities** (was 2 high)
- `npm run lint` → green (eslint + stylelint)
- `hugo --environment production --gc` with the pinned **0.164.0 extended** and **Dart Sass 1.79.5** → exit 0, 6 pages. (`bin/prod` not run — it targets the Netlify image; Dart Sass installed separately at the version `bin/prod` pins.)
- **Built output is byte-identical before and after.** Built `public/` with the old lockfile and the new one and compared a sha256 over every file: `064cc411…3428b4` both times. The bump is provably inert to the deployed site.

The Sass deprecation warnings in the build log are pre-existing Bootstrap `mixed-decls` warnings, unrelated to this change.

Not self-merging — over to you. The Netlify deploy preview is the remaining check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GShY9W5RfEFEa2YsgyE88z)_